### PR TITLE
 Update Dockerfile for Dynamic Port Configuration and Improved Flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,22 @@ FROM python:3.10-slim
 # Set the working directory in the container
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    gcc \
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y --no-install-recommends gcc \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apt-get remove -y gcc && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the current directory contents into the container at /app
+# Copy the rest of the application code
 COPY . /app
 
-# Install any needed packages specified in requirements.txt
-COPY requirements.txt /app/
-RUN pip install --no-cache-dir -r requirements.txt
+# Expose the application port
+ENV PORT=8000
+EXPOSE $PORT
 
-# Make port 8000 available to the world outside this container
-EXPOSE 8000
-
-# Define environment variable for Redis (can be overridden)
+# Define environment variable for Redis
 ENV REDIS_URL=redis://redis:6379/0
 
-# Run the application the main file is in api folder
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
-
+# Run the application
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "$PORT"]


### PR DESCRIPTION

Implemented configuration through ENV variable

This pull request updates the Dockerfile to make the port configuration dynamic. The port is now set through an environment variable (PORT) rather than being hardcoded to 8000. This enhances the flexibility of the application, allowing the port to be easily overridden at runtime without modifying the Dockerfile.

Modified Code:

ENV PORT=8000
EXPOSE $PORT

# Define environment variable for Redis
ENV REDIS_URL=redis://redis:6379/0

# Run the application
CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "$PORT"] 

##########------Standard devops practice-----#############