### PR TITLE
fix: fallback to username if name is null

### DIFF
--- a/modules/github_fetcher.py
+++ b/modules/github_fetcher.py
@@ -117,7 +117,7 @@ class GitHubProfileFetcher:
             featured = GitHubProjectRanker().get_featured(username)
             return {
                 'username': username,
-                'name': graphql_data.get('name', username),
+                'name': graphql_data.get('name') or username,
                 'bio': graphql_data.get('bio', ''),
                 'location': graphql_data.get('location', ''),
                 'avatar_url': graphql_data.get('avatarUrl', ''),


### PR DESCRIPTION
## Summary
Fallback to the `username` when the `name` field is null in the GitHub profile fetcher.

## Description
Updated the `name` field logic in the `GitHubProfileFetcher` class. Previously, it used `graphql_data.get('name', username)` as a fallback when `name` was null. Now, it has been updated to `graphql_data.get('name') or username` for better readability and functionality.

## Motivation and Context
This change ensures that if the `name` field is null, the `username` is used as a fallback. This resolves the issue of profiles displaying `none` when the `name` field is missing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
