### PR TITLE
fix(tests): add env vars to test workflow

### DIFF
--- a/.github/workflows/pyunittest.yml
+++ b/.github/workflows/pyunittest.yml
@@ -36,7 +36,10 @@ jobs:
         run: |
           source .venv/bin/activate  # Activate the uv-created virtual environment
           pytest --cov=.  # Run pytest directly, generating coverage for the entire project
-
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          API_KEYS: ${{ secrets.API_KEYS }}
       # Step 4: Generate a coverage report
       - name: Generate coverage report
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pyunittest.yml` file. The change adds environment variables to the `jobs:` section to ensure that necessary API keys are available during the test execution.

* [`.github/workflows/pyunittest.yml`](diffhunk://#diff-b2fc8a3ffafb6586d4dbb575cf325219dd63b6dc8840964b0448e39593646b6cL39-R42): Added `API_TOKEN_GITHUB`, `GROQ_API_KEY`, and `API_KEYS` environment variables to the `jobs:` section.