### PR TITLE
Update weekly_sync.yml

### DIFF
--- a/.github/workflows/weekly_sync.yml
+++ b/.github/workflows/weekly_sync.yml
@@ -1,8 +1,6 @@
 name: Weekly sync
 
 on:
-  schedule:
-    - cron: '0 0 * * 0' # Every Sunday
   workflow_dispatch:  # This allows you to manually trigger the workflow from the Actions tab.
 
 permissions:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/weekly_sync.yml` file to modify the trigger for the weekly sync workflow.

* Removed the cron schedule trigger that ran every Sunday and kept the manual trigger option via `workflow_dispatch`.