### PR TITLE
[Fix] resolve Invalid redirect URL for Linkedin link on resume

### DIFF
--- a/www/lib/resume.tsx
+++ b/www/lib/resume.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import type { LinkedInProfile } from "@/types/types";
+import type { LinkedInProfile, Profile, SocialAccount } from "@/types/types";
 import {
   getLinkedInProfileData,
   getProfileData,
@@ -142,7 +142,7 @@ const formatExperienceDuration = (
   end?: {
     month?: number;
     year?: number;
-  } | null,
+  } | null
 ) => {
   const startMonth = start.month ? getMonthString(start.month) : "";
   const startYear = start.year;
@@ -208,7 +208,7 @@ const ResumeDocument = ({ data }: { data: ResumeData }) => (
                 <Text style={styles.text}>
                   {formatExperienceDuration(
                     experience.duration.start,
-                    experience.duration.end,
+                    experience.duration.end
                   )}
                 </Text>
               </View>
@@ -313,10 +313,22 @@ const ResumeDocument = ({ data }: { data: ResumeData }) => (
   </Document>
 );
 
+const getLinkedInUsername = (userProfile: Profile | any) => {
+  if (!userProfile) return null;
+  const linkedInAccount = userProfile?.social_accounts?.find(
+    (account: SocialAccount) => account.provider === "linkedin"
+  );
+  const username =
+    linkedInAccount?.url?.split("in/").pop()?.replace("/", "") || "";
+
+  return username || null;
+};
+
 async function getResumeData(username: string): Promise<ResumeData> {
   const userProfile = await getProfileData(username);
   const userProjects = await getProjectData(username);
-  const userLinkedInProfile = await getLinkedInProfileData(username);
+  const linkedInUsername = getLinkedInUsername(userProfile);
+  const userLinkedInProfile = await getLinkedInProfileData(linkedInUsername);
 
   const defaultLinkedInProfile: LinkedInProfile = {
     experience: [],


### PR DESCRIPTION
## Summary
Closes #102
Resolve invalid redirect URL issue for Linkedin link on resume

## Description
The LinkedIn profile URL shows `https://www.linked/in/None`. This indicates an issue with an invalid username being used when trying to access the LinkedIn profile.

## Motivation and Context
This issue is crucial to fix because invalid LinkedIn links damage user experience and credibility. When a user tries to access a LinkedIn profile and is redirected to an invalid page, it leads to frustration and makes the platform seem unreliable. Correcting this ensures users can properly connect and view professional profiles, which is essential for a functional and trustworthy system.

## Screenshots:
[Screencast from 2025-05-21 19-57-49.webm](https://github.com/user-attachments/assets/d127e008-3d4e-418d-a818-05f2892fcac3)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
