### PR TITLE
fix: show only last 6 months of contributions chart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Jinja2==3.1.4
 MarkupSafe==3.0.2
 multidict==6.1.0
 numpy
-pendulum==3.0.0
+pendulum==3.2.0
 propcache==0.2.1
 pydantic==2.10.3
 pydantic_core==2.27.1

--- a/www/components/ProfileSection.tsx
+++ b/www/components/ProfileSection.tsx
@@ -181,17 +181,13 @@ export async function ProfileSection({
               <h2 className="font-bold mb-4">
                 {user.achievements?.total_contributions} Contributions
               </h2>
-              <div className="overflow-hidden">
-                <div className="relative w-full" style={{ height: "100px" }}>
-                  <img
-                    className="absolute top-[32%] left-1/2 transform -translate-x-124 -translate-y-1/2 scale-[1]"
-                    src={`https://ghchart.rshah.org/5F8417/${user.username}`}
-                    alt={`${user.name}'s GitHub contributions`}
-                    style={{
-                      maxWidth: "none",
-                    }}
-                  />
-                </div>
+              <div className="w-full overflow-hidden rounded-lg relative" style={{ height: "100px" }}>
+                <img
+                  className="absolute right-0 top-0 h-full w-auto block"
+                  style={{ maxWidth: "none" }}
+                  src={`https://ghchart.rshah.org/5F8417/${user.username}`}
+                  alt={`${user.name}'s GitHub contributions`}
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
Fix GitHub contributions chart containment and crop to show only the last 6 months.

## Description
Replaced broken absolute-positioned chart rendering in `ProfileSection.tsx` with a properly contained layout. The chart image is now pinned to the right edge of a fixed-height `overflow-hidden` container, which naturally clips the older (left) portion of the SVG, showing only the most recent ~6 months of activity.

## Motivation and Context
The contributions chart from `ghchart.rshah.org` was overflowing its parent container due to a combination of `absolute` positioning with arbitrary offsets (`top-[32%]`, `-translate-x-124`) and `maxWidth: none` — causing the image to bleed outside the card boundary. Additionally, showing the full year made the chart too small and visually noisy; the last 6 months is more relevant and readable at card width.

Also bumps `pendulum` from `3.0.0` → `3.2.0` in `requirements.txt`.


## How has this been tested?
Tested locally via `pnpm dev` on the Next.js dev server. Verified the chart renders correctly within the card bounds at multiple viewport widths (mobile and desktop) without overflow. Confirmed the right half (most recent activity) of the SVG is visible and properly clipped on the left.

## Screenshots (if appropriate):
**Before:**
![before](https://github.com/user-attachments/assets/38d111d7-0b2d-4261-be44-fa2fbaf4ccac)

**After:**
![after](https://github.com/user-attachments/assets/6474ab2f-0196-458f-8cb4-bad9166388d2)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.