### PR TITLE
fix: use renderToBuffer to fix resume download (#89)

### DIFF
--- a/www/app/api/resume/route.ts
+++ b/www/app/api/resume/route.ts
@@ -10,10 +10,8 @@ export async function GET(request: NextRequest) {
       return Response.json({ error: "Username is required" }, { status: 400 });
     }
 
-    const pdfInstance = await generateResumePDF(username);
-    const pdfBuffer = await pdfInstance.toBuffer();
+    const pdfBuffer = await generateResumePDF(username);
 
-    //@ts-expect-error -- todo: fix this later
     return new Response(pdfBuffer, {
       headers: {
         "Content-Type": "application/pdf",

--- a/www/components/ClientResumeButton.tsx
+++ b/www/components/ClientResumeButton.tsx
@@ -25,7 +25,9 @@ export default function ClientResumeButton({ username }: { username: string }) {
       const a = document.createElement("a");
       a.href = url;
       a.download = `${username}-resume.pdf`;
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Error downloading resume:", error);

--- a/www/components/ClientResumeButton.tsx
+++ b/www/components/ClientResumeButton.tsx
@@ -22,9 +22,14 @@ export default function ClientResumeButton({ username }: { username: string }) {
 
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
-      window.open(url, "_blank");
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${username}-resume.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Error downloading resume:", error);
+      alert("Failed to generate resume. Please try again.");
     } finally {
       setIsLoading(false);
     }

--- a/www/lib/resume.tsx
+++ b/www/lib/resume.tsx
@@ -3,7 +3,7 @@ import {
   Image,
   Link,
   Page,
-  pdf,
+  renderToBuffer,
   StyleSheet,
   Text,
   View,
@@ -379,7 +379,7 @@ async function getResumeData(username: string): Promise<ResumeData> {
   };
 }
 
-export async function generateResumePDF(username: string) {
+export async function generateResumePDF(username: string): Promise<Buffer> {
   const resumeData = await getResumeData(username);
-  return pdf(<ResumeDocument data={resumeData} />);
+  return renderToBuffer(<ResumeDocument data={resumeData} />);
 }


### PR DESCRIPTION
## Problem

The "Download Resume" button fails with `Error: Failed to generate resume` because `pdf().toBuffer()` from `@react-pdf/renderer` returns a `PDFDocument` object, **not** a Node.js `Buffer`. Passing this to `new Response()` results in an unusable response body.

## Fix

- Replace `pdf(<Doc />).toBuffer()` with `renderToBuffer(<Doc />)` — the correct server-side API that returns a real `Buffer`
- Remove the `@ts-expect-error` hack in `route.ts` (no longer needed)
- Use `<a download>` instead of `window.open()` to avoid popup blockers
- Show user-facing `alert` on failure instead of silent `console.error`

## Testing

1. Run `cd www && npm install && npm run dev`
2. Visit `http://localhost:3000/<any-github-username>`
3. Click the Download Resume button — PDF should download directly
4. Also test `http://localhost:3000/api/resume?username=torvalds` directly — should return a PDF file

Fixes #89